### PR TITLE
fix: remove patch.crates-io path overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "presentar-core"
-version = "0.3.3"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec076597046cb63e9c064b708e010ab98a1f48db4c0004e8192724e383a6c8d"
 dependencies = [
  "serde",
  "serde_json",
@@ -1030,7 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "presentar-terminal"
-version = "0.3.3"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc9e13136a2d3490fde1d76d0450cca37268a280e95d814964a41efa31bcc"
 dependencies = [
  "bitvec",
  "compact_str",
@@ -1043,7 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "presentar-test"
-version = "0.3.3"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5931e9eddaa55e9d8fc1bb787c2b2479af5d0bd424819e153a75130ab3f47796"
 dependencies = [
  "presentar-core",
  "presentar-test-macros",
@@ -1053,7 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "presentar-test-macros"
-version = "0.3.3"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc6b2c2c5a5492e16100287096cadf10fa7586190f6d104188cf2309a81ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1698,9 +1706,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "trueno"
-version = "0.14.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35d2c230ebde5da651c4dc89c32bfe0d277f4e36750a5849d2e69af50b646211"
+checksum = "90b0f08c743a6d63e691f80624e67e306e83f9bc532ebc618b2352cd02126e7e"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ ratatui = { version = "0.29", optional = true }
 crossterm = { version = "0.28", optional = true }
 # ComputeBlocks from presentar-terminal (SIMD-optimized TUI widgets)
 # Path deps to avoid jugar-probar prod dep chain (CB-081)
-presentar-terminal = { version = "0.3", path = "../presentar/crates/presentar-terminal", optional = true }
-presentar-core = { version = "0.3", path = "../presentar/crates/presentar-core", default-features = false, optional = true }
+presentar-terminal = { version = "0.3", optional = true }
+presentar-core = { version = "0.3", default-features = false, optional = true }
 
 # WASM (optional)
 wasm-bindgen = { version = "0.2", optional = true }
@@ -94,7 +94,7 @@ tempfile = "3.14"
 # jugar-probar removed from dev-deps to reduce Cargo.lock (CB-081)
 # Tests in tests/probar_*.rs require jugar-probar and are gated via required-features
 # Presentar TUI testing framework (SPEC-024 Section 12 & 13)
-presentar-test = { version = "0.3", path = "../presentar/crates/presentar-test" }
+presentar-test = { version = "0.3" }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

- Remove `path = "../presentar/..."` overrides from `presentar-terminal`, `presentar-core` (optional TUI deps), and `presentar-test` (dev-dep)
- All three crates are published to crates.io (v0.3.4/v0.3.5), so version-only resolution works correctly
- Cargo.lock updated to resolve these from crates.io instead of local paths

## Why

Hard-coded `path = "../..."` entries in `[dependencies]` and `[dev-dependencies]` break clean-room CI builds when the sibling `../presentar` repo is not present alongside simular. The clean-room gate (`gates-lib.sh` Mode A) strips these at build time, but having them committed is a maintenance hazard and masks potential version conflicts.

Spec: `sovereign-stack-protected-branch-strategy.md` (Section 5b) — all repos must resolve dependencies from published crates, not local path overrides.

## Test plan

- [x] `cargo check` passes with crates.io-resolved presentar deps
- [x] Lockfile updated: `presentar-core v0.3.4`, `presentar-terminal v0.3.5`, `presentar-test v0.3.4` now from registry
- [ ] Clean-room Mode A gate passes (no longer needs to strip path overrides)
- [ ] Clean-room Mode B gate passes (tests compile and pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)