### PR TITLE
ci: replace CI with sovereign-ci.yml caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,94 +1,21 @@
-# Per-repo CI workflow — self-hosted clean-room runners for sovereignty (§2.1.1)
-# Spec: docs/specifications/unified-ci-pipeline.md
-#
-# Calls the unified reusable gate workflow in paiml/.github.
-# Branch protection requires "unified / gate" to pass before merge.
-
+# Sovereign CI — calls reusable workflow from paiml/.github
+# Change once in paiml/.github → applies to all repos
 name: CI
 
 on:
-  pull_request_target:
-    branches: [main, master]
   push:
     branches: [main, master]
-  workflow_dispatch:  # manual trigger for testing
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
 
-# One CI run per branch/PR; cancel stale runs on same branch
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  unified:
-    uses: paiml/.github/.github/workflows/unified-gate.yml@main
+  ci:
+    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
-      pr_sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
-
-  test:
-    runs-on: [self-hosted, clean-room]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: simular
-      - name: Checkout presentar
-        uses: actions/checkout@v4
-        with:
-          repository: paiml/presentar
-          path: presentar
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            simular/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('simular/**/Cargo.lock') }}
-      - run: cd simular && cargo test --lib
-
-  coverage:
-    runs-on: [self-hosted, clean-room]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: simular
-      - name: Checkout presentar
-        uses: actions/checkout@v4
-        with:
-          repository: paiml/presentar
-          path: presentar
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            simular/target
-          key: ${{ runner.os }}-cargo-cov-${{ hashFiles('simular/**/Cargo.lock') }}
-      - run: cargo install cargo-llvm-cov --locked || true
-      - run: cd simular && cargo llvm-cov test --lib --lcov --output-path lcov.info
-      - uses: codecov/codecov-action@v4
-        with:
-          files: simular/lcov.info
-        continue-on-error: true
-
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install cargo-audit --locked || true
-      - run: cargo audit
-
-  gate:
-    name: gate
-    runs-on: [self-hosted, clean-room]
-    if: always()
-    needs: [test, coverage, security]
-    steps:
-      - name: Check all jobs
-        run: |
-          if [ "${{ needs.test.result }}" = "failure" ] || [ "${{ needs.coverage.result }}" = "failure" ]; then
-            exit 1
-          fi


### PR DESCRIPTION
## Summary
- Replaces ~100 line per-repo CI with 21-line reusable workflow call
- Single source of truth: `paiml/.github/.github/workflows/sovereign-ci.yml`
- Fixes red badge issue from previous merge conflicts

## Test plan
- [ ] Verify sovereign-ci.yml workflow triggers on push/PR
- [ ] Confirm all gates (test/lint/coverage/security) run via reusable workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)